### PR TITLE
test: Add unit tests and mock data for Authentication, Teachers, Users, and Sessions

### DIFF
--- a/front/src/app/features/sessions/services/session-api.service.spec.ts
+++ b/front/src/app/features/sessions/services/session-api.service.spec.ts
@@ -3,20 +3,207 @@ import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
 
 import { SessionApiService } from './session-api.service';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { Session } from '../interfaces/session.interface';
+import { sessionApiPath, sessionsMock } from 'src/app/mocks/session-api.mocks';
 
-describe('SessionsService', () => {
+describe('SessionApiService', () => {
   let service: SessionApiService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports:[
-        HttpClientModule
-      ]
+      imports: [HttpClientTestingModule],
+      providers: [SessionApiService],
     });
     service = TestBed.inject(SessionApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('all()', () => {
+    it('should retrieve all sessions', () => {
+      const response: Session[] = sessionsMock;
+      service.all().subscribe((sessions) => {
+        expect(sessions).toEqual(response);
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}`);
+      expect(req.request.method).toBe('GET');
+      req.flush(response);
+    });
+
+    it('should handle error when retrieving all sessions', () => {
+      service.all().subscribe({
+        next: () => fail('expected an error, not sessions'),
+        error: (error) => expect(error.status).toBe(500),
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}`);
+      expect(req.request.method).toBe('GET');
+      req.flush('Server error', { status: 500, statusText: 'Server Error' });
+    });
+
+    it('should handle empty response when retrieving all sessions', () => {
+      service.all().subscribe((sessions) => {
+        expect(sessions).toEqual([]);
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}`);
+      expect(req.request.method).toBe('GET');
+      req.flush([]);
+    });
+  });
+
+  describe('detail()', () => {
+    it('should retrieve session details by ID', () => {
+      const response: Session = sessionsMock[0];
+      service.detail('1').subscribe((session) => {
+        expect(session).toEqual(response);
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(response);
+    });
+
+    it('should handle error when retrieving session details by ID', () => {
+      service.detail('1').subscribe({
+        next: () => fail('expected an error, not a session'),
+        error: (error) => expect(error.status).toBe(404),
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('GET');
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle null response when retrieving session details by ID', () => {
+      service.detail('1').subscribe((session) => {
+        expect(session).toBeNull();
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(null);
+    });
+  });
+
+  describe('delete()', () => {
+    it('should delete a session by ID', () => {
+      service.delete('1').subscribe((response) => {
+        expect(response).toBeTruthy();
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({});
+    });
+
+    it('should handle error when deleting a session by ID', () => {
+      service.delete('1').subscribe({
+        next: () => fail('expected an error, not a confirmation'),
+        error: (error) => expect(error.status).toBe(500),
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Server error', { status: 500, statusText: 'Server Error' });
+    });
+  });
+
+  describe('create()', () => {
+    it('should create a new session', () => {
+      const newSession: Session = sessionsMock[0];
+      service.create(newSession).subscribe((session) => {
+        expect(session).toEqual(newSession);
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}`);
+      expect(req.request.method).toBe('POST');
+      req.flush(newSession);
+    });
+
+    it('should handle error when creating a new session', () => {
+      const newSession: Session = sessionsMock[0];
+      service.create(newSession).subscribe({
+        next: () => fail('expected an error, not a session'),
+        error: (error) => expect(error.status).toBe(400),
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}`);
+      expect(req.request.method).toBe('POST');
+      req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
+    });
+  });
+
+  describe('update()', () => {
+    it('should update an existing session', () => {
+      const updatedSession: Session = sessionsMock[0];
+      service.update('1', updatedSession).subscribe((session) => {
+        expect(session).toEqual(updatedSession);
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('PUT');
+      req.flush(updatedSession);
+    });
+
+    it('should handle error when updating an existing session', () => {
+      const updatedSession: Session = sessionsMock[0];
+      service.update('1', updatedSession).subscribe({
+        next: () => fail('expected an error, not a session'),
+        error: (error) => expect(error.status).toBe(404),
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}/1`);
+      expect(req.request.method).toBe('PUT');
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  describe('participate()', () => {
+    it('should add a user to a session', () => {
+      service.participate('1', '1').subscribe((response) => {
+        expect(response).toBeUndefined();
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}/1/participate/1`);
+      expect(req.request.method).toBe('POST');
+      req.flush({});
+    });
+
+    it('should handle error when adding a user to a session', () => {
+      service.participate('1', '1').subscribe({
+        next: () => fail('expected an error, not a response'),
+        error: (error) => expect(error.status).toBe(500),
+      });
+      const req = httpMock.expectOne(`${sessionApiPath}/1/participate/1`);
+      expect(req.request.method).toBe('POST');
+      req.flush('Server error', { status: 500, statusText: 'Server Error' });
+    });
+
+    it('should remove a user from a session', () => {
+      service.unParticipate('1', '1').subscribe((response) => {
+        expect(response).toBeUndefined();
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}/1/participate/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({});
+    });
+
+    it('should handle error when removing a user from a session', () => {
+      service.unParticipate('1', '1').subscribe({
+        next: () => fail('expected an error, not a response'),
+        error: (error) => expect(error.status).toBe(500),
+      });
+
+      const req = httpMock.expectOne(`${sessionApiPath}/1/participate/1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Server error', { status: 500, statusText: 'Server Error' });
+    });
   });
 });

--- a/front/src/app/mocks/session-api.mocks.ts
+++ b/front/src/app/mocks/session-api.mocks.ts
@@ -1,0 +1,24 @@
+import { Session } from '../features/sessions/interfaces/session.interface';
+
+export const sessionApiPath = 'api/session';
+
+export const sessionsMock: Session[] = [
+  {
+    id: 1,
+    name: 'Session 1',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
+    date: new Date('2025-03-01T00:00:00Z'),
+    teacher_id: 1,
+    users: [],
+  },
+  {
+    id: 2,
+    name: 'Session 2',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
+    date: new Date('2024-12-29T00:00:00Z'),
+    teacher_id: 2,
+    users: [],
+  },
+];

--- a/front/src/app/mocks/session.mocks.ts
+++ b/front/src/app/mocks/session.mocks.ts
@@ -1,0 +1,12 @@
+import { SessionInformation } from '../interfaces/sessionInformation.interface';
+
+export const userRequestMock: SessionInformation = {
+  token:
+    'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ5b2dhQHN0dWRpby5jb20iLCJpYXQiOjE3MzkyNjk0MDAsImV4cCI6MTczOTM1NTgwMH0.QBnFSkldurGOIjhHX-NYym9UXHCngbYp6ZdM_SsYnHxpGcUbQLsrGnunVrM6eLbtx2icTVtDK36Zj0yw0bdpfQ',
+  type: 'Bearer',
+  id: 3,
+  username: 'yoga@studio.com',
+  firstName: 'Admin',
+  lastName: 'Admin',
+  admin: true,
+};

--- a/front/src/app/mocks/teacher.mocks.ts
+++ b/front/src/app/mocks/teacher.mocks.ts
@@ -1,0 +1,27 @@
+import { Teacher } from '../interfaces/teacher.interface';
+
+export const teacherPath = 'api/teacher';
+
+export const getAllTeachersResponseMock: Teacher[] = [
+  {
+    id: 1,
+    lastName: 'Teacher 1',
+    firstName: 'Test 1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 2,
+    lastName: 'Teacher 2',
+    firstName: 'Test 2',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 3,
+    lastName: 'Teacher 3',
+    firstName: 'Test 2',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];

--- a/front/src/app/mocks/user.mocks.ts
+++ b/front/src/app/mocks/user.mocks.ts
@@ -1,0 +1,13 @@
+import { User } from '../interfaces/user.interface';
+
+export const userPath = 'api/user';
+
+export const getUserResponseMock: User = {
+  id: 1,
+  email: 'test_user@mail.com',
+  lastName: 'User',
+  firstName: 'Test',
+  admin: false,
+  password: 'password123',
+  createdAt: new Date(),
+};

--- a/front/src/app/services/session.service.spec.ts
+++ b/front/src/app/services/session.service.spec.ts
@@ -2,6 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
 
 import { SessionService } from './session.service';
+import { SessionInformation } from '../interfaces/sessionInformation.interface';
+import { userRequestMock } from '../mocks/session.mocks';
+import { first } from 'rxjs';
 
 describe('SessionService', () => {
   let service: SessionService;
@@ -13,5 +16,45 @@ describe('SessionService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should log in a user', () => {
+    const user: SessionInformation = userRequestMock;
+    service.logIn(user);
+
+    expect(service.isLogged).toBe(true);
+    expect(service.sessionInformation).toEqual(user);
+  });
+
+  it('should log out a user', () => {
+    service.logOut();
+
+    expect(service.isLogged).toBe(false);
+    expect(service.sessionInformation).toBeUndefined();
+  });
+
+  it('should emit isLogged as true when user logs in', (done) => {
+    const user: SessionInformation = userRequestMock;
+
+    service.$isLogged().subscribe((isLogged) => {
+      if (isLogged) {
+        expect(isLogged).toBe(true);
+        done();
+      }
+    });
+
+    service.logIn(user);
+  });
+
+  it('should emit isLogged as false when user logs out', (done) => {
+    service
+      .$isLogged()
+      .pipe(first())
+      .subscribe((isLogged) => {
+        expect(isLogged).toBe(false);
+        done();
+      });
+
+    service.logOut();
   });
 });

--- a/front/src/app/services/teacher.service.spec.ts
+++ b/front/src/app/services/teacher.service.spec.ts
@@ -3,20 +3,100 @@ import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
 
 import { TeacherService } from './teacher.service';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { Teacher } from '../interfaces/teacher.interface';
+import {
+  getAllTeachersResponseMock,
+  teacherPath,
+} from '../mocks/teacher.mocks';
 
 describe('TeacherService', () => {
   let service: TeacherService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports:[
-        HttpClientModule
-      ]
+      imports: [HttpClientTestingModule],
+      providers: [TeacherService],
     });
     service = TestBed.inject(TeacherService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should fetch all teachers', () => {
+    const response: Teacher[] = getAllTeachersResponseMock;
+    service.all().subscribe((teachers) => {
+      expect(teachers).toEqual(response);
+    });
+
+    const req = httpMock.expectOne(teacherPath);
+    expect(req.request.method).toBe('GET');
+    req.flush(response);
+  });
+
+  it('should fetch teacher detail by id', () => {
+    const response: Teacher = getAllTeachersResponseMock[0];
+    service.detail('1').subscribe((teacher) => {
+      expect(teacher).toEqual(response);
+    });
+    const req = httpMock.expectOne(`${teacherPath}/1`);
+    expect(req.request.method).toBe('GET');
+    req.flush(response);
+  });
+
+  it('should handle error when fetching all teachers', () => {
+    service.all().subscribe({
+      next: () => fail('expected an error, not teachers'),
+      error: (error) => expect(error.status).toBe(500),
+    });
+
+    const req = httpMock.expectOne(teacherPath);
+    expect(req.request.method).toBe('GET');
+    req.flush('Something went wrong', {
+      status: 500,
+      statusText: 'Server Error',
+    });
+  });
+
+  it('should handle error when fetching teacher detail by id', () => {
+    service.detail('1').subscribe({
+      next: () => fail('expected an error, not a teacher'),
+      error: (error) => expect(error.status).toBe(404),
+    });
+
+    const req = httpMock.expectOne(`${teacherPath}/1`);
+    expect(req.request.method).toBe('GET');
+    req.flush('Not found', { status: 404, statusText: 'Not Found' });
+  });
+
+  it('should handle empty response when fetching all teachers', () => {
+    service.all().subscribe((teachers) => {
+      expect(teachers).toEqual([]);
+    });
+
+    const req = httpMock.expectOne(teacherPath);
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('should handle null response when fetching teacher detail by id', () => {
+    service.detail('1').subscribe((teacher) => {
+      expect(teacher).toBeNull();
+    });
+
+    const req = httpMock.expectOne(`${teacherPath}/1`);
+    expect(req.request.method).toBe('GET');
+    req.flush(null);
   });
 });

--- a/front/src/app/services/user.service.spec.ts
+++ b/front/src/app/services/user.service.spec.ts
@@ -1,22 +1,72 @@
-import { HttpClientModule } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
-
 import { UserService } from './user.service';
+import { User } from '../interfaces/user.interface';
+import { getUserResponseMock, userPath } from '../mocks/user.mocks';
 
 describe('UserService', () => {
   let service: UserService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports:[
-        HttpClientModule
-      ]
+      imports: [HttpClientTestingModule],
+      providers: [UserService],
     });
     service = TestBed.inject(UserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should retrieve user by id', () => {
+    const response: User = getUserResponseMock;
+    service.getById('1').subscribe((user) => {
+      expect(user).toEqual(response);
+    });
+    const req = httpMock.expectOne(`${userPath}/1`);
+    expect(req.request.method).toBe('GET');
+    req.flush(response);
+  });
+
+  it('should delete user by id', () => {
+    service.delete('1').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+    const req = httpMock.expectOne(`${userPath}/1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+  });
+
+  it("should handle error when id to retrieve doesn't exist", () => {
+    service.getById('1').subscribe({
+      next: () => fail('expected an error, not a user'),
+      error: (error) => expect(error.status).toBe(404),
+    });
+
+    const req = httpMock.expectOne(`${userPath}/1`);
+    expect(req.request.method).toBe('GET');
+    req.flush('Server error', { status: 404, statusText: 'Not found' });
+  });
+
+  it("should handle error when id to delete doesn't exist", () => {
+    service.delete('1').subscribe({
+      next: () => fail('expected an error, not a confirmation'),
+      error: (error) => expect(error.status).toBe(404),
+    });
+
+    const req = httpMock.expectOne(`${userPath}/1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush('Server error', { status: 404, statusText: 'Not found' });
   });
 });


### PR DESCRIPTION
This pull request adds unit tests across multiple services, focusing on login/logout functionality, user and teacher data retrieval, and session management. It introduces mock data for users, teachers, and sessions to ensure test consistency. It also replaces the `HttpClientModule` with `HttpClientTestingModule` for better isolation during testing, and verifies HTTP requests in all tests. Error handling and edge cases such as empty responses and missing data are properly covered.