### PR TITLE
test: Add unit tests and mocks for session handling and guards

### DIFF
--- a/front/src/app/guards/auth.guard.spec.ts
+++ b/front/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AuthGuard } from './auth.guard';
+import { SessionService } from '../services/session.service';
+import { expect } from '@jest/globals';
+import { createRouterMock, loginResponseMock  } from '../mocks/auth.mocks';
+import { createSessionServiceMock } from '../mocks/session.mocks';
+
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let router: jest.Mocked<Router>;
+  let sessionService: jest.Mocked<SessionService>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AuthGuard,
+        { provide: Router, useValue: createRouterMock() },
+        { provide: SessionService, useValue: createSessionServiceMock() },
+      ],
+    });
+
+    guard = TestBed.inject(AuthGuard);
+    router = TestBed.inject(Router) as jest.Mocked<Router>;
+    sessionService = TestBed.inject(SessionService) as jest.Mocked<SessionService>;
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should return true and not navigate when user is logged in', () => {
+    sessionService.isLogged = true;
+    const result = guard.canActivate();
+    expect(result).toBe(true);
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should return false and navigate to login when user is not logged in', () => {
+    sessionService.isLogged = false;
+    const result = guard.canActivate();
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['login']);
+    expect(router.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle edge cases when sessionInformation is undefined but isLogged is true', () => {
+    sessionService.isLogged = true;
+    sessionService.sessionInformation = undefined;
+    const result = guard.canActivate();
+    expect(result).toBe(true);
+  });
+
+  it('should properly handle state changes through SessionService', () => {
+    // Test initial state
+    expect(guard.canActivate()).toBe(false);
+
+    // Simulate user login
+    sessionService.isLogged = true;
+    sessionService.sessionInformation = {
+      ...loginResponseMock,
+      admin: false,
+    };
+
+    expect(guard.canActivate()).toBe(true);
+
+    // Simulate logout
+    sessionService.isLogged = false;
+    sessionService.sessionInformation = undefined;
+    expect(guard.canActivate()).toBe(false);
+  });
+});

--- a/front/src/app/guards/unauth.guard.spec.ts
+++ b/front/src/app/guards/unauth.guard.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { UnauthGuard } from './unauth.guard';
+import { SessionService } from '../services/session.service';
+import { expect } from '@jest/globals';
+import { createRouterMock } from '../mocks/auth.mocks';
+import { createSessionServiceMock } from '../mocks/session.mocks';
+
+
+describe('UnauthGuard', () => {
+  let guard: UnauthGuard;
+  let router: jest.Mocked<Router>;
+  let sessionService: jest.Mocked<SessionService>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        UnauthGuard,
+        { provide: Router, useValue: createRouterMock() },
+        { provide: SessionService, useValue: createSessionServiceMock() },
+      ],
+    });
+
+    guard = TestBed.inject(UnauthGuard);
+    router = TestBed.inject(Router) as jest.Mocked<Router>;
+    sessionService = TestBed.inject(SessionService) as jest.Mocked<SessionService>;
+  });
+
+  it('should create the guard', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should implement CanActivate', () => {
+    expect(typeof guard.canActivate).toBe('function');
+  });
+
+  it('should return false and navigate to rentals when user is logged in', () => {
+    sessionService.isLogged = true;
+    const result = guard.canActivate();
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['rentals']);
+    expect(router.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return true and not navigate when user is not logged in', () => {
+    sessionService.isLogged = false;
+    const result = guard.canActivate();
+    expect(result).toBe(true);
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/front/src/app/interceptors/jwt.interceptor.spec.ts
+++ b/front/src/app/interceptors/jwt.interceptor.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { JwtInterceptor } from './jwt.interceptor';
+import { SessionService } from '../services/session.service';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { expect } from '@jest/globals';
+import { createSessionServiceMock } from '../mocks/session.mocks';
+
+describe('JwtInterceptor', () => {
+  let interceptor: JwtInterceptor;
+  let sessionService: SessionService;
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        JwtInterceptor,
+        { provide: SessionService, useValue: createSessionServiceMock() },
+        { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
+      ],
+    });
+
+    interceptor = TestBed.inject(JwtInterceptor);
+    httpMock = TestBed.inject(HttpTestingController);
+    httpClient = TestBed.inject(HttpClient);
+    sessionService = TestBed.inject(SessionService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+
+  it('should add authorization header when user is logged in', () => {
+    sessionService.isLogged = true;
+    const testUrl = '/api/test';
+    httpClient.get(testUrl).subscribe();
+    const httpRequest = httpMock.expectOne(testUrl);
+    expect(httpRequest.request.headers.has('Authorization')).toBeTruthy();
+    expect(httpRequest.request.headers.get('Authorization')).toBe(
+      'Bearer ' + sessionService.sessionInformation!.token
+    );
+  });
+
+  it('should not add authorization header when user is not logged in', () => {
+    sessionService.isLogged = false;
+    const testUrl = '/api/test';
+    httpClient.get(testUrl).subscribe();
+    const httpRequest = httpMock.expectOne(testUrl);
+    expect(httpRequest.request.headers.has('Authorization')).toBeFalsy();
+  });
+});

--- a/front/src/app/mocks/auth.mocks.ts
+++ b/front/src/app/mocks/auth.mocks.ts
@@ -1,0 +1,46 @@
+import { SessionInformation } from 'src/app/interfaces/sessionInformation.interface';
+import { LoginRequest } from '../features/auth/interfaces/loginRequest.interface';
+import { RegisterRequest } from '../features/auth/interfaces/registerRequest.interface';
+import { Router } from '@angular/router';
+import { SessionService } from '../services/session.service';
+
+export const authPath = 'api/auth';
+
+export const loginResponseMock: SessionInformation = {
+  token:
+    'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ5b2dhQHN0dWRpby5jb20iLCJpYXQiOjE3MzkyNjk0MDAsImV4cCI6MTczOTM1NTgwMH0.QBnFSkldurGOIjhHX-NYym9UXHCngbYp6ZdM_SsYnHxpGcUbQLsrGnunVrM6eLbtx2icTVtDK36Zj0yw0bdpfQ',
+  type: 'Bearer',
+  id: 3,
+  username: 'yoga@studio.com',
+  firstName: 'Admin',
+  lastName: 'Admin',
+  admin: true,
+};
+
+export const loginRequestMock: LoginRequest = {
+  email: 'yoga@studio.com',
+  password: 'test!1234',
+};
+
+export const invalidLoginRequestMock: LoginRequest = {
+  email: 'invalid-email',
+  password: '123',
+};
+
+export const registerRequestMock: RegisterRequest = {
+  email: 'test_user@mail.com',
+  firstName: 'Test',
+  lastName: 'User',
+  password: 'password123',
+};
+
+export const invalidRegisterRequestMock: RegisterRequest = {
+  email: 'invalid-email',
+  firstName: '',
+  lastName: '',
+  password: '123',
+};
+
+export const createRouterMock = (): Partial<jest.Mocked<Router>> => ({
+  navigate: jest.fn(),
+});

--- a/front/src/app/mocks/session.mocks.ts
+++ b/front/src/app/mocks/session.mocks.ts
@@ -1,4 +1,5 @@
 import { SessionInformation } from '../interfaces/sessionInformation.interface';
+import { SessionService } from '../services/session.service';
 
 export const userRequestMock: SessionInformation = {
   token:
@@ -10,3 +11,7 @@ export const userRequestMock: SessionInformation = {
   lastName: 'Admin',
   admin: true,
 };
+
+export const createSessionServiceMock = (): Partial<jest.Mocked<SessionService>> => ({
+  isLogged: false,
+});

--- a/front/src/app/mocks/session.mocks.ts
+++ b/front/src/app/mocks/session.mocks.ts
@@ -1,3 +1,4 @@
+import { of } from 'rxjs';
 import { SessionInformation } from '../interfaces/sessionInformation.interface';
 import { SessionService } from '../services/session.service';
 

--- a/front/src/app/mocks/session.mocks.ts
+++ b/front/src/app/mocks/session.mocks.ts
@@ -14,4 +14,8 @@ export const userRequestMock: SessionInformation = {
 
 export const createSessionServiceMock = (): Partial<jest.Mocked<SessionService>> => ({
   isLogged: false,
+  sessionInformation: userRequestMock,
+  $isLogged: jest.fn().mockReturnValue(of(false)),
+  logIn: jest.fn(),
+  logOut: jest.fn(),
 });


### PR DESCRIPTION
This pull request includes the addition of unit tests for the `JwtInterceptor`, `UnauthGuard`, and `AuthGuard` with mocked `SessionService` methods and mock data for authentication requests and responses. 