### PR TITLE
test: Add unit tests for UserService, TeacherService, and SessionService

### DIFF
--- a/back/src/test/java/com/openclassrooms/starterjwt/services/SessionServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/services/SessionServiceTest.java
@@ -1,0 +1,242 @@
+package com.openclassrooms.starterjwt.services;
+
+import com.openclassrooms.starterjwt.exception.BadRequestException;
+import com.openclassrooms.starterjwt.exception.NotFoundException;
+import com.openclassrooms.starterjwt.models.Session;
+import com.openclassrooms.starterjwt.models.User;
+import com.openclassrooms.starterjwt.repository.SessionRepository;
+import com.openclassrooms.starterjwt.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@SpringBootTest
+public class SessionServiceTest {
+
+    private SessionService sessionService;
+
+    @MockBean
+    private SessionRepository sessionRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    public SessionServiceTest(SessionService sessionService) {
+        this.sessionService = sessionService;
+    }
+
+    private Session session;
+    private User user;
+    private final Long SESSION_ID = 1L;
+    private final Long USER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        session = new Session();
+        session.setId(SESSION_ID);
+        session.setUsers(new ArrayList<>());
+
+        user = new User();
+        user.setId(USER_ID);
+    }
+
+    @Nested
+    @DisplayName("Tests for create method")
+    class CreateTests {
+        @Test
+        @DisplayName("Should create a session")
+        void create_ShouldReturnCreatedSession() {
+            when(sessionRepository.save(any(Session.class))).thenReturn(session);
+            Session result = sessionService.create(session);
+            assertNotNull(result);
+            assertEquals(SESSION_ID, result.getId());
+            verify(sessionRepository, times(1)).save(session);
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for delete method")
+    class DeleteTests {
+        @Test
+        @DisplayName("Should delete a session")
+        void delete_ShouldCallRepositoryDeleteById() {
+            sessionService.delete(SESSION_ID);
+            verify(sessionRepository, times(1)).deleteById(SESSION_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for findAll method")
+    class FindAllTests {
+        @Test
+        @DisplayName("Should return all sessions")
+        void findAll_ShouldReturnAllSessions() {
+            Session session2 = new Session();
+            session2.setId(2L);
+            List<Session> sessions = Arrays.asList(session, session2);
+            when(sessionRepository.findAll()).thenReturn(sessions);
+            List<Session> result = sessionService.findAll();
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertEquals(sessions, result);
+            verify(sessionRepository, times(1)).findAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for getById method")
+    class GetByIdTests {
+        @Test
+        @DisplayName("Should return session when it exists")
+        void getById_ShouldReturnSession_WhenSessionExists() {
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            Session result = sessionService.getById(SESSION_ID);
+            assertNotNull(result);
+            assertEquals(SESSION_ID, result.getId());
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+        }
+
+        @Test
+        @DisplayName("Should return null when session doesn't exist")
+        void getById_ShouldReturnNull_WhenSessionDoesNotExist() {
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
+            Session result = sessionService.getById(SESSION_ID);
+            assertNull(result);
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for update method")
+    class UpdateTests {
+        @Test
+        @DisplayName("Should update session")
+        void update_ShouldReturnUpdatedSession() {
+            Session updatedSession = new Session();
+            updatedSession.setId(2L);
+            when(sessionRepository.save(any(Session.class))).thenReturn(updatedSession);
+            Session result = sessionService.update(SESSION_ID, updatedSession);
+            assertNotNull(result);
+            verify(sessionRepository, times(1)).save(updatedSession);
+            assertEquals(SESSION_ID, updatedSession.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for participate method")
+    class ParticipateTests {
+        @Test
+        @DisplayName("Should add user to session participants")
+        void participate_ShouldAddUserToSession_WhenUserNotAlreadyParticipating() {
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            sessionService.participate(SESSION_ID, USER_ID);
+            assertTrue(session.getUsers().contains(user));
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(userRepository, times(1)).findById(USER_ID);
+            verify(sessionRepository, times(1)).save(session);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when session doesn't exist")
+        void participate_ShouldThrowNotFoundException_WhenSessionDoesNotExist() {
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            assertThrows(NotFoundException.class, () -> {
+                sessionService.participate(SESSION_ID, USER_ID);
+            });
+            
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(sessionRepository, never()).save(any(Session.class));
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when user doesn't exist")
+        void participate_ShouldThrowNotFoundException_WhenUserDoesNotExist() {
+            
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+            assertThrows(NotFoundException.class, () -> {
+                sessionService.participate(SESSION_ID, USER_ID);
+            });
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(userRepository, times(1)).findById(USER_ID);
+            verify(sessionRepository, never()).save(any(Session.class));
+        }
+
+        @Test
+        @DisplayName("Should throw BadRequestException when user already participates")
+        void participate_ShouldThrowBadRequestException_WhenUserAlreadyParticipates() {
+            session.getUsers().add(user);
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+            assertThrows(BadRequestException.class, () -> {
+                sessionService.participate(SESSION_ID, USER_ID);
+            });
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(userRepository, times(1)).findById(USER_ID);
+            verify(sessionRepository, never()).save(any(Session.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for noLongerParticipate method")
+    class NoLongerParticipateTests {
+        @Test
+        @DisplayName("Should remove user from session participants")
+        void noLongerParticipate_ShouldRemoveUserFromSession_WhenUserIsParticipating() {
+            session.getUsers().add(user);
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            sessionService.noLongerParticipate(SESSION_ID, USER_ID);
+            assertFalse(session.getUsers().contains(user));
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(sessionRepository, times(1)).save(session);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when session doesn't exist")
+        void noLongerParticipate_ShouldThrowNotFoundException_WhenSessionDoesNotExist() {
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
+            assertThrows(NotFoundException.class, () -> {
+                sessionService.noLongerParticipate(SESSION_ID, USER_ID);
+            });
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(sessionRepository, never()).save(any(Session.class));
+        }
+
+        @Test
+        @DisplayName("Should throw BadRequestException when user is not participating")
+        void noLongerParticipate_ShouldThrowBadRequestException_WhenUserIsNotParticipating() {
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            assertThrows(BadRequestException.class, () -> {
+                sessionService.noLongerParticipate(SESSION_ID, USER_ID);
+            });
+            verify(sessionRepository, times(1)).findById(SESSION_ID);
+            verify(sessionRepository, never()).save(any(Session.class));
+        }
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/services/TeacherServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/services/TeacherServiceTest.java
@@ -1,0 +1,102 @@
+package com.openclassrooms.starterjwt.services;
+
+import com.openclassrooms.starterjwt.mocks.TeacherMocks;
+import com.openclassrooms.starterjwt.models.Teacher;
+import com.openclassrooms.starterjwt.repository.TeacherRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+
+@SpringBootTest
+public class TeacherServiceTest {
+
+    private TeacherService teacherService;
+    private TeacherMocks teacherMocks = new TeacherMocks();
+
+    @MockBean
+    private TeacherRepository teacherRepository;
+
+    @Autowired
+    public TeacherServiceTest(TeacherService teacherService) {
+        this.teacherService = teacherService;
+    }
+
+    private Teacher teacher;
+    private final Long TEACHER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        teacher = teacherMocks.createTeacher(TEACHER_ID, "Teacher", "André", false);
+    }
+
+    @Nested
+    @DisplayName("Tests for findAll method")
+    class FindAllTests {
+        @Test
+        @DisplayName("Should return all teachers")
+        void findAll_ShouldReturnAllTeachers() {
+            Teacher teacher2 = teacherMocks.createTeacher(2L, "Teacher", "John", false);
+
+            List<Teacher> teachers = Arrays.asList(teacher, teacher2);
+            when(teacherRepository.findAll()).thenReturn(teachers);
+            List<Teacher> result = teacherService.findAll();
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertEquals(teachers, result);
+            verify(teacherRepository, times(1)).findAll();
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no teachers exist")
+        void findAll_ShouldReturnEmptyList_WhenNoTeachersExist() {
+            when(teacherRepository.findAll()).thenReturn(Arrays.asList());
+            List<Teacher> result = teacherService.findAll();
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+            verify(teacherRepository, times(1)).findAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for findById method")
+    class FindByIdTests {
+        @Test
+        @DisplayName("Should return teacher when it exists")
+        void findById_ShouldReturnTeacher_WhenTeacherExists() {
+            when(teacherRepository.findById(TEACHER_ID)).thenReturn(Optional.of(teacher));
+            Teacher result = teacherService.findById(TEACHER_ID);
+
+            assertNotNull(result);
+            assertEquals(TEACHER_ID, result.getId());
+            assertEquals("Teacher", result.getLastName());
+            assertEquals("André", result.getFirstName());
+            verify(teacherRepository, times(1)).findById(TEACHER_ID);
+        }
+
+        @Test
+        @DisplayName("Should return null when teacher doesn't exist")
+        void findById_ShouldReturnNull_WhenTeacherDoesNotExist() {
+            when(teacherRepository.findById(TEACHER_ID)).thenReturn(Optional.empty());
+            Teacher result = teacherService.findById(TEACHER_ID);
+            assertNull(result);
+            verify(teacherRepository, times(1)).findById(TEACHER_ID);
+        }
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/services/UserServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/services/UserServiceTest.java
@@ -1,0 +1,98 @@
+package com.openclassrooms.starterjwt.services;
+
+import com.openclassrooms.starterjwt.mocks.UserMocks;
+import com.openclassrooms.starterjwt.models.User;
+import com.openclassrooms.starterjwt.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class UserServiceTest {
+
+    private UserService userService;
+    private UserMocks userMocks = new UserMocks();
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    public UserServiceTest(UserService userService) {
+        this.userService = userService;
+    }
+
+    private User user;
+    private final Long USER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        user = userMocks.createUser(USER_ID, "andre@mail.com", "Test", "André", "test123", false, false);
+    }
+
+    @Nested
+    @DisplayName("Tests for delete method")
+    class DeleteTests {
+        @Test
+        @DisplayName("Should delete a user successfully")
+        void delete_ShouldCallRepositoryDeleteById() {
+            userService.delete(USER_ID);
+            verify(userRepository, times(1)).deleteById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("Should handle null ID")
+        void delete_ShouldHandleNullId() {
+            userService.delete(null);
+            verify(userRepository, times(1)).deleteById(null);
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for findById method")
+    class FindByIdTests {
+        @Test
+        @DisplayName("Should return user when it exists")
+        void findById_ShouldReturnUser_WhenUserExists() {
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            User result = userService.findById(USER_ID);
+
+            assertNotNull(result);
+            assertEquals(USER_ID, result.getId());
+            assertEquals("andre@mail.com", result.getEmail());
+            assertEquals("André", result.getFirstName());
+            assertEquals("Test", result.getLastName());
+            verify(userRepository, times(1)).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("Should return null when user doesn't exist")
+        void findById_ShouldReturnNull_WhenUserDoesNotExist() {
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+            User result = userService.findById(USER_ID);
+            assertNull(result);
+            verify(userRepository, times(1)).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("Should handle null ID")
+        void findById_ShouldHandleNullId() {
+            when(userRepository.findById(null)).thenReturn(Optional.empty());
+            User result = userService.findById(null);
+            assertNull(result);
+            verify(userRepository, times(1)).findById(null);
+        }
+    }
+}


### PR DESCRIPTION
 This PR introduces unit tests for `UserService`, `TeacherService`, and `SessionService` to ensure correct behavior and improve test coverage.  

- **UserService**: Tests for `delete` and `findById`, handling valid and null inputs.  
- **TeacherService**: Tests for `findAll` and `findById`, verifying expected results and empty cases.  
- **SessionService**: Comprehensive tests for `create`, `delete`, `findAll`, `getById`, `update`, `participate`, and `noLongerParticipate`, including error handling for missing entities and invalid actions.  

Mocks `UserRepository` and `TeacherRepository` using Mockito for database interactions.