### PR TITLE
test:  Add integration tests for Repositories and configure H2 database for testing

### DIFF
--- a/back/src/test/java/com/openclassrooms/starterjwt/repository/SessionRepositoryTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/repository/SessionRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.openclassrooms.starterjwt.repository;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.openclassrooms.starterjwt.mocks.SessionMocks;
+import com.openclassrooms.starterjwt.models.Session;
+import com.openclassrooms.starterjwt.models.Teacher;
+
+@SpringBootTest
+@TestPropertySource("classpath:application-test.properties")
+public class SessionRepositoryTest {
+
+    private final SessionRepository sessionRepository;
+    private final TeacherRepository teacherRepository;
+    private final SessionMocks sessionMocks = new SessionMocks();
+
+    @Autowired
+    public SessionRepositoryTest(SessionRepository sessionRepository,  TeacherRepository teacherRepository) {
+        this.sessionRepository = sessionRepository;
+        this.teacherRepository = teacherRepository;
+    }
+
+    private Session session;
+    Session savedSessionInDB;
+
+    @BeforeEach
+    public void setup() {
+        List<Teacher> teachers = teacherRepository.findAll();
+        assertFalse(teachers.isEmpty());
+        Teacher teacher = teachers.get(0);
+        session = sessionMocks.createSession(null, teacher, null, false, false);
+        savedSessionInDB = sessionRepository.save(session);
+    }
+
+    @Test
+    @DisplayName("Save a session")
+    public void shouldSaveSession() {
+        assertNotNull(savedSessionInDB.getId());
+        assertEquals(session.getName(), savedSessionInDB.getName());
+        assertEquals(session.getDescription(), savedSessionInDB.getDescription());
+        assertEquals(session.getTeacher().getFirstName(), savedSessionInDB.getTeacher().getFirstName());
+        assertEquals(session.getTeacher().getLastName(), savedSessionInDB.getTeacher().getLastName());
+    }
+
+    @Test
+    @DisplayName("Find all sessions")
+    public void shouldFindAllSessions() {
+        sessionRepository.deleteAll();
+        List<Session> sessions = sessionRepository.findAll();
+        assertTrue(sessions.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Find session by id")
+    public void shouldFindSessionById() {
+        Session foundSession = sessionRepository.findById(savedSessionInDB.getId()).orElse(null);
+        assertNotNull(foundSession);
+        assertEquals(savedSessionInDB.getId(), foundSession.getId());
+        assertEquals(savedSessionInDB.getName(), foundSession.getName());
+        assertEquals(savedSessionInDB.getDescription(), foundSession.getDescription());
+        assertEquals(savedSessionInDB.getTeacher().getFirstName(), foundSession.getTeacher().getFirstName());
+        assertEquals(savedSessionInDB.getTeacher().getLastName(), foundSession.getTeacher().getLastName());
+    }
+
+    @Test
+    @DisplayName("Delete session")
+    public void shouldDeleteSession() {
+        sessionRepository.deleteById(savedSessionInDB.getId());
+        assertFalse(sessionRepository.findById(savedSessionInDB.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("Update session")
+    public void shouldUpdateSession() {
+        savedSessionInDB.setName("Session de Yoga pour les débutants");
+        savedSessionInDB.setDescription("Session de yoga pour les débutants avec des exercices simples");
+        savedSessionInDB.setDate(Date.valueOf(LocalDate.of(2025, 3, 11)));
+        Session updatedSessionInDB = sessionRepository.save(savedSessionInDB);
+        assertEquals(savedSessionInDB.getId(), updatedSessionInDB.getId());
+        assertEquals(savedSessionInDB.getName(), updatedSessionInDB.getName());
+        assertEquals(savedSessionInDB.getDescription(), updatedSessionInDB.getDescription());
+        assertEquals(savedSessionInDB.getDate(), updatedSessionInDB.getDate());
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/repository/TeacherRepositoryTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/repository/TeacherRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.openclassrooms.starterjwt.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.openclassrooms.starterjwt.mocks.TeacherMocks;
+import com.openclassrooms.starterjwt.models.Teacher;
+
+@SpringBootTest
+@TestPropertySource("classpath:application-test.properties")
+public class TeacherRepositoryTest {
+    private final TeacherRepository teacherRepository;
+    private final TeacherMocks teacherMocks = new TeacherMocks();
+    private Teacher teacher;
+
+    @Autowired
+    public TeacherRepositoryTest(TeacherRepository teacherRepository) {
+        this.teacherRepository = teacherRepository;
+    }
+
+    @BeforeEach
+    public void cleanUp() {
+        teacher = teacherMocks.createTeacher(1L, "Teacher", "André", false);
+    }
+
+    @Test
+    public void shouldSaveTeacher() {
+        Teacher savedTeacherInDB = teacherRepository.save(teacher);
+        assertNotNull(savedTeacherInDB.getId());
+        assertEquals(teacher.getFirstName(), savedTeacherInDB.getFirstName());
+        assertEquals(teacher.getLastName(), savedTeacherInDB.getLastName());
+    }
+
+    @Test
+    public void shouldFindAllTeachers() {
+        assertNotNull(teacherRepository.findAll());
+    }
+
+    @Test
+    public void shouldFindTeacherById() {
+        Teacher savedTeacherInDB = teacherRepository.save(teacher);
+        Teacher teacherInDB = teacherRepository.findById(savedTeacherInDB.getId()).orElse(null);
+        assertNotNull(teacherInDB);
+        assertEquals(teacher.getFirstName(), teacherInDB.getFirstName());
+        assertEquals(teacher.getLastName(), teacherInDB.getLastName());
+    }
+
+    @Test
+    public void shouldDeleteTeacher() {
+        Teacher savedTeacherInDB = teacherRepository.save(teacher);
+        teacherRepository.deleteById(savedTeacherInDB.getId());
+        Teacher teacherInDB = teacherRepository.findById(savedTeacherInDB.getId()).orElse(null);
+        assertEquals(null, teacherInDB);
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/repository/UserRepositoryTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/repository/UserRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.openclassrooms.starterjwt.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.openclassrooms.starterjwt.mocks.UserMocks;
+import com.openclassrooms.starterjwt.models.User;
+
+@SpringBootTest
+@TestPropertySource("classpath:application-test.properties")
+public class UserRepositoryTest {
+
+    private final UserRepository userRepository;
+    private final UserMocks userMocks = new UserMocks();
+    private User user;
+
+    @Autowired
+    public UserRepositoryTest(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+
+    @BeforeEach
+    public void setup() {
+        user = userMocks.createUser(1L, "andre_test@mail.com", "André", "password!123", "private!123", false, false );
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldSaveUser() {
+        User savedUserInDB = userRepository.save(user);
+        assertNotNull(savedUserInDB.getId());
+        assertEquals(user.getEmail(), savedUserInDB.getEmail());
+        assertEquals(user.getLastName(), savedUserInDB.getLastName());
+        assertEquals(user.getFirstName(), savedUserInDB.getFirstName());
+        assertEquals(user.getPassword(), savedUserInDB.getPassword());
+        assertEquals(user.isAdmin(), savedUserInDB.isAdmin());
+    }
+
+    @Test
+    public void shouldFindAllUsers() {
+        assertNotNull(userRepository.findAll());
+    }
+
+    @Test
+    public void shouldFindUserById() {
+        User savedUserInDB = userRepository.save(user);
+        User userInDB = userRepository.findById(savedUserInDB.getId()).orElse(null);
+        assertNotNull(userInDB);
+        assertEquals(user.getEmail(), userInDB.getEmail());
+        assertEquals(user.getLastName(), userInDB.getLastName());
+        assertEquals(user.getFirstName(), userInDB.getFirstName());
+        assertEquals(user.getPassword(), userInDB.getPassword());
+        assertEquals(user.isAdmin(), userInDB.isAdmin());
+    }
+
+    @Test
+    public void shouldDeleteUser() {
+        User savedUserInDB = userRepository.save(user);
+        userRepository.deleteById(savedUserInDB.getId());
+        User userInDB = userRepository.findById(savedUserInDB.getId()).orElse(null);
+        assertEquals(null, userInDB);
+    }
+
+}

--- a/back/src/test/resources/application-test.properties
+++ b/back/src/test/resources/application-test.properties
@@ -1,0 +1,14 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+
+spring.sql.init.mode=always
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.h2.console.settings.trace=false
+spring.h2.console.settings.web-allow-others=false

--- a/back/src/test/resources/data.sql
+++ b/back/src/test/resources/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO TEACHERS (first_name, last_name)
+VALUES ('Margot', 'DELAHAYE'),
+       ('Hélène', 'THIERCELIN');
+
+
+INSERT INTO USERS (first_name, last_name, admin, email, password)
+VALUES ('Admin', 'Admin', true, 'yoga@studio.com', '$2a$10$.Hsa/ZjUVaHqi0tp9xieMeewrnZxrZ5pQRzddUXE/WjDu2ZThe6Iq'); 
+


### PR DESCRIPTION
This pull request introduces integration tests for the `UserRepository`, `TeacherRepository`, and `SessionRepository`, covering CRUD operations. Additionally, initial data for teachers and users has been added to the database. It also configures an H2 in-memory database for testing purposes.