### PR TITLE
test: Add unit tests for Mappers: User, Teacher, and Session

### DIFF
--- a/back/src/test/java/com/openclassrooms/starterjwt/mapper/SessionMapperTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/mapper/SessionMapperTest.java
@@ -1,0 +1,229 @@
+package com.openclassrooms.starterjwt.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.openclassrooms.starterjwt.dto.SessionDto;
+import com.openclassrooms.starterjwt.mocks.SessionMocks;
+import com.openclassrooms.starterjwt.mocks.TeacherMocks;
+import com.openclassrooms.starterjwt.mocks.UserMocks;
+import com.openclassrooms.starterjwt.models.Session;
+import com.openclassrooms.starterjwt.models.Teacher;
+import com.openclassrooms.starterjwt.models.User;
+import com.openclassrooms.starterjwt.services.TeacherService;
+import com.openclassrooms.starterjwt.services.UserService;
+
+@SpringBootTest
+public class SessionMapperTest {
+
+    private final SessionMapper sessionMapper;
+    private final SessionMocks sessionMocks = new SessionMocks();
+    private final UserMocks userMocks = new UserMocks();
+    private final TeacherMocks teacherMocks = new TeacherMocks();
+
+    @Autowired
+    public SessionMapperTest(SessionMapper sessionMapper) {
+        this.sessionMapper = sessionMapper;
+    }
+
+    @MockBean
+    private TeacherService teacherService;
+
+    @MockBean
+    private UserService userService;
+
+    private Teacher teacher;
+    private User firstUser, secondUser;
+    private List<User> users;
+
+    @BeforeEach
+    public void setUp() {
+        teacher = teacherMocks.createTeacher(1L, "Test", "John", false);
+        firstUser = userMocks.createUser(1L, "jean_test@mail.com", "Test", "Jean", "password", false, false);
+        secondUser = userMocks.createUser(2L, "paul_test@mail.com", "Test", "Paul", "password", false, false);
+        users = Arrays.asList(firstUser, secondUser);
+    }
+
+    @Test
+    @DisplayName("Map Session entity to SessionDto")
+    public void shouldMapSessionEntityToSessionDto() {
+        Session session = sessionMocks.createSession(null, teacher, users, false, false);
+        SessionDto sessionDto = sessionMapper.toDto(session);
+
+        assertNotNull(sessionDto);
+        assertEquals(session.getId(), sessionDto.getId());
+        assertEquals(session.getName(), sessionDto.getName());
+        assertEquals(session.getDescription(), sessionDto.getDescription());
+        assertEquals(session.getTeacher().getId(), sessionDto.getTeacher_id());
+        assertEquals(session.getUsers().get(0).getId(), sessionDto.getUsers().get(0));
+        assertEquals(session.getUsers().get(1).getId(), sessionDto.getUsers().get(1));
+        assertNotNull(sessionDto.getUsers());
+        assertEquals(2, sessionDto.getUsers().size());
+        assertTrue(sessionDto.getUsers().contains(session.getUsers().get(0).getId()));
+        assertTrue(sessionDto.getUsers().contains(session.getUsers().get(1).getId()));
+    }
+
+    @Test
+    @DisplayName("Map SessionDto to Session entity")
+    public void shouldMapDtoToEntity() {
+        SessionDto sessionDto = sessionMocks.createSessionDto(null, null, teacher.getId(), users, false, false);
+
+        when(teacherService.findById(teacher.getId())).thenReturn(teacher);
+        when(userService.findById(1L)).thenReturn(firstUser);
+        when(userService.findById(2L)).thenReturn(secondUser);
+
+        Session session = sessionMapper.toEntity(sessionDto);
+
+        assertNotNull(session);
+        assertEquals(sessionDto.getId(), session.getId());
+        assertEquals(sessionDto.getName(), session.getName());
+        assertEquals(sessionDto.getDescription(), session.getDescription());
+        assertNotNull(session.getTeacher());
+        assertEquals(teacher.getId(), session.getTeacher().getId());
+        assertNotNull(session.getUsers());
+        assertEquals(2, session.getUsers().size());
+        assertEquals(firstUser.getId(), session.getUsers().get(0).getId());
+        assertEquals(secondUser.getId(), session.getUsers().get(1).getId());
+    }
+
+    @Test
+    @DisplayName("Map list of Session entities to list of SessionDtos")
+    public void shouldMapSessionListToDtoList() {
+        List<Session> sessions = Arrays.asList(
+            sessionMocks.createSession(null, teacher, users, false, false),
+            sessionMocks.createSession(null, teacher, users, true, false)
+        );
+
+        List<SessionDto> sessionDtos = sessionMapper.toDto(sessions);
+
+        assertNotNull(sessionDtos);
+        assertEquals(2, sessionDtos.size());
+        assertEquals(sessions.get(0).getId(), sessionDtos.get(0).getId());
+        assertEquals(sessions.get(0).getName(), sessionDtos.get(0).getName());
+        assertEquals(sessions.get(0).getDescription(), sessionDtos.get(0).getDescription());
+        assertEquals(sessions.get(0).getTeacher().getId(), sessionDtos.get(0).getTeacher_id());
+        assertEquals(sessions.get(0).getUsers().get(0).getId(), sessionDtos.get(0).getUsers().get(0));
+        assertEquals(sessions.get(0).getUsers().get(1).getId(), sessionDtos.get(0).getUsers().get(1));
+        assertEquals(sessions.get(1).getId(), sessionDtos.get(1).getId());
+        assertEquals(sessions.get(1).getName(), sessionDtos.get(1).getName());
+        assertEquals(sessions.get(1).getDescription(), sessionDtos.get(1).getDescription());
+        assertNull(sessionDtos.get(1).getTeacher_id());
+        assertNotNull(sessionDtos.get(1).getUsers());
+        assertTrue(sessionDtos.get(1).getUsers().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Map list of SessionDtos to list of Session entities")
+    public void shouldMapDtoListToSessionList() {
+        List<SessionDto> sessionDtos = Arrays.asList(
+            sessionMocks.createSessionDto(null, null, teacher.getId(), users, false, false),
+            sessionMocks.createSessionDto(null, null, teacher.getId(), users, true, false)
+        );
+
+        when(teacherService.findById(teacher.getId())).thenReturn(teacher);
+        when(userService.findById(1L)).thenReturn(firstUser);
+        when(userService.findById(2L)).thenReturn(secondUser);
+
+        List<Session> sessions = sessionMapper.toEntity(sessionDtos);
+
+        assertNotNull(sessions);
+        assertEquals(2, sessions.size());
+        assertEquals(sessionDtos.get(0).getId(), sessions.get(0).getId());
+        assertEquals(sessionDtos.get(0).getName(), sessions.get(0).getName());
+        assertEquals(sessionDtos.get(0).getDescription(), sessions.get(0).getDescription());
+        assertNotNull(sessions.get(0).getTeacher());
+        assertEquals(teacher.getId(), sessions.get(0).getTeacher().getId());
+        assertNotNull(sessions.get(0).getUsers());
+        assertEquals(2, sessions.get(0).getUsers().size());
+        assertEquals(firstUser.getId(), sessions.get(0).getUsers().get(0).getId());
+        assertEquals(secondUser.getId(), sessions.get(0).getUsers().get(1).getId());
+        assertEquals(sessionDtos.get(1).getId(), sessions.get(1).getId());
+        assertEquals(sessionDtos.get(1).getName(), sessions.get(1).getName());
+        assertEquals(sessionDtos.get(1).getDescription(), sessions.get(1).getDescription());
+        assertNull(sessions.get(1).getTeacher());
+        assertNotNull(sessions.get(1).getUsers());
+        assertTrue(sessions.get(1).getUsers().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Handle null values in Session to SessionDto mapping")
+    public void shouldHandleNullValuesInSessionToDto() {
+        Session session = sessionMocks.createSession(null, teacher, users, true, false);
+        SessionDto dto = sessionMapper.toDto(session);
+
+        assertNotNull(dto);
+        assertEquals(session.getId(), dto.getId());
+        assertEquals(session.getName(), dto.getName());
+        assertEquals(session.getDescription(), dto.getDescription());
+        assertNull(dto.getTeacher_id());
+        assertNotNull(dto.getUsers());
+        assertTrue(dto.getUsers().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Handle null values in SessionDto to Session mapping")
+    public void shouldHandleNullValuesInDtoToEntity() {
+        SessionDto dto = sessionMocks.createSessionDto(null, null, teacher.getId(), users, true, false);
+        Session session = sessionMapper.toEntity(dto);
+
+        assertNotNull(session);
+        assertEquals(dto.getId(), session.getId());
+        assertEquals(dto.getName(), session.getName());
+        assertEquals(dto.getDescription(), session.getDescription());
+        assertNull(session.getTeacher());
+        assertNotNull(session.getUsers());
+        assertTrue(session.getUsers().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Handle long values in Session to SessionDto mapping")
+    public void shouldHandleLongValuesInSessionToDto() {
+        Session session = sessionMocks.createSession(null, teacher, users, false, true);
+        SessionDto dto = sessionMapper.toDto(session);
+
+        assertNotNull(dto);
+        assertEquals(session.getId(), dto.getId());
+        assertEquals(session.getName(), dto.getName());
+        assertEquals(session.getDescription(), dto.getDescription());
+        assertEquals(session.getTeacher().getId(), dto.getTeacher_id());
+        assertEquals(session.getUsers().get(0).getId(), dto.getUsers().get(0));
+        assertEquals(session.getUsers().get(1).getId(), dto.getUsers().get(1));
+    }
+
+    @Test
+    @DisplayName("Handle long values in SessionDto to Session mapping")
+    public void shouldHandleLongValuesInDtoToEntity() {
+        SessionDto dto = sessionMocks.createSessionDto(null, null, teacher.getId(), users, false, true);
+
+        when(teacherService.findById(teacher.getId())).thenReturn(teacher);
+        when(userService.findById(1L)).thenReturn(firstUser);
+        when(userService.findById(2L)).thenReturn(secondUser);
+
+        Session session = sessionMapper.toEntity(dto);
+
+        assertNotNull(session);
+        assertEquals(dto.getId(), session.getId());
+        assertEquals(dto.getName(), session.getName());
+        assertEquals(dto.getDescription(), session.getDescription());
+        assertNotNull(session.getTeacher());
+        assertEquals(teacher.getId(), session.getTeacher().getId());
+        assertNotNull(session.getUsers());
+        assertEquals(2, session.getUsers().size());
+        assertEquals(firstUser.getId(), session.getUsers().get(0).getId());
+        assertEquals(secondUser.getId(), session.getUsers().get(1).getId());
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/mapper/TeacherMapperTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/mapper/TeacherMapperTest.java
@@ -1,0 +1,120 @@
+package com.openclassrooms.starterjwt.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.openclassrooms.starterjwt.dto.TeacherDto;
+import com.openclassrooms.starterjwt.mocks.TeacherMocks;
+import com.openclassrooms.starterjwt.models.Teacher;
+
+@SpringBootTest
+public class TeacherMapperTest {
+
+    private final TeacherMapper teacherMapper;
+    private final TeacherMocks teacherMocks = new TeacherMocks();
+
+    @Autowired
+    public TeacherMapperTest(TeacherMapper teacherMapper) {
+        this.teacherMapper = teacherMapper;
+    }
+
+    @Test
+    @DisplayName("Map Teacher entity to TeacherDto")
+    public void shouldMapTeacherEntityToTeacherDto() {
+        Teacher teacher = teacherMocks.createTeacher(1L, "Test", "John", false);
+
+        TeacherDto teacherDto = teacherMapper.toDto(teacher);
+
+        assertNotNull(teacherDto);
+        assertEquals(teacher.getId(), teacherDto.getId());
+        assertEquals(teacher.getLastName(), teacherDto.getLastName());
+        assertEquals(teacher.getFirstName(), teacherDto.getFirstName());
+        assertEquals(teacher.getCreatedAt(), teacherDto.getCreatedAt());
+        assertEquals(teacher.getUpdatedAt(), teacherDto.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Map TeacherDto to Teacher entity")
+    public void shouldMapTeacherDtoToTeacherEntity() {
+        TeacherDto teacherDto = teacherMocks.createTeacherDto(1L, "Test", "Jane", false);
+        Teacher teacher = teacherMapper.toEntity(teacherDto);
+
+        assertNotNull(teacher);
+        assertEquals(teacherDto.getId(), teacher.getId());
+        assertEquals(teacherDto.getLastName(), teacher.getLastName());
+        assertEquals(teacherDto.getFirstName(), teacher.getFirstName());
+        assertEquals(teacherDto.getCreatedAt(), teacher.getCreatedAt());
+        assertEquals(teacherDto.getUpdatedAt(), teacher.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Map list of Teacher entities to list of TeacherDtos")
+    public void shouldMapTeacherListToDtoList() {
+        List<Teacher> teachers = Arrays.asList(
+            teacherMocks.createTeacher(1L, "Test", "Mike", false),
+            teacherMocks.createTeacher(2L, "Test", "Sarah", false)
+        );
+
+        List<TeacherDto> teacherDtos = teacherMapper.toDto(teachers);
+        assertNotNull(teacherDtos);
+        assertEquals(2, teacherDtos.size());
+        assertEquals(teachers.get(0).getId(), teacherDtos.get(0).getId());
+        assertEquals(teachers.get(0).getLastName(), teacherDtos.get(0).getLastName());
+        assertEquals(teachers.get(0).getFirstName(), teacherDtos.get(0).getFirstName());
+        assertEquals(teachers.get(1).getId(), teacherDtos.get(1).getId());
+        assertEquals(teachers.get(1).getLastName(), teacherDtos.get(1).getLastName());
+        assertEquals(teachers.get(1).getFirstName(), teacherDtos.get(1).getFirstName());
+    }
+
+    @Test
+    @DisplayName("Map list of TeacherDtos to list of Teacher entities")
+    public void shouldMapDtoListToTeacherList() {
+        List<TeacherDto> teacherDtos = Arrays.asList(
+            teacherMocks.createTeacherDto(1L, "Brown", "Robert", false),
+            teacherMocks.createTeacherDto(2L, "Davis", "Emily", false)
+        );
+
+        List<Teacher> teachers = teacherMapper.toEntity(teacherDtos);
+
+        assertNotNull(teachers);
+        assertEquals(2, teachers.size());
+        assertEquals(teacherDtos.get(0).getId(), teachers.get(0).getId());
+        assertEquals(teacherDtos.get(0).getLastName(), teachers.get(0).getLastName());
+        assertEquals(teacherDtos.get(0).getFirstName(), teachers.get(0).getFirstName());
+        assertEquals(teacherDtos.get(1).getId(), teachers.get(1).getId());
+        assertEquals(teacherDtos.get(1).getLastName(), teachers.get(1).getLastName());
+        assertEquals(teacherDtos.get(1).getFirstName(), teachers.get(1).getFirstName());
+    }
+
+
+    @Test
+    @DisplayName("Handle long values in Teacher to TeacherDto mapping")
+    public void shouldHandleLongValuesInTeacherToDto() {
+        Teacher teacher = teacherMocks.createTeacher(1L, "A".repeat(30), "B".repeat(30), true);
+        TeacherDto teacherDto = teacherMapper.toDto(teacher);
+
+        assertNotNull(teacherDto);
+        assertEquals(teacher.getId(), teacherDto.getId());
+        assertEquals(teacher.getLastName(), teacherDto.getLastName());
+        assertEquals(teacher.getFirstName(), teacherDto.getFirstName());
+    }
+
+    @Test
+    @DisplayName("Handle long values in TeacherDto to Teacher mapping")
+    public void shouldHandleLongValuesInDtoToTeacher() {
+        TeacherDto teacherDto = teacherMocks.createTeacherDto(1L, "C".repeat(30), "D".repeat(30), true);
+        Teacher teacher = teacherMapper.toEntity(teacherDto);
+        assertNotNull(teacher);
+        assertEquals(teacherDto.getId(), teacher.getId());
+        assertEquals(teacherDto.getLastName(), teacher.getLastName());
+        assertEquals(teacherDto.getFirstName(), teacher.getFirstName());
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/mapper/UserMapperTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/mapper/UserMapperTest.java
@@ -1,0 +1,151 @@
+package com.openclassrooms.starterjwt.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.openclassrooms.starterjwt.dto.UserDto;
+import com.openclassrooms.starterjwt.mocks.UserMocks;
+import com.openclassrooms.starterjwt.models.User;
+
+@SpringBootTest
+public class UserMapperTest {
+   private final UserMapper userMapper;
+   private final UserMocks userMocks = new UserMocks();
+
+    @Autowired
+    public UserMapperTest(UserMapper userMapper) {
+        this.userMapper = userMapper;
+    }
+
+    @Test
+    @DisplayName("Map User entity to UserDto")
+    public void shouldMapUserEntityToUserDto() {
+        User user = userMocks.createUser(1L, "andré.test@mail.com", "Test", "André", "password123", true, false);
+        UserDto userDto = userMapper.toDto(user);
+
+        assertNotNull(userDto);
+        assertEquals(user.getId(), userDto.getId());
+        assertEquals(user.getEmail(), userDto.getEmail());
+        assertEquals(user.getLastName(), userDto.getLastName());
+        assertEquals(user.getFirstName(), userDto.getFirstName());
+        assertEquals(user.getPassword(), userDto.getPassword());
+        assertEquals(user.isAdmin(), userDto.isAdmin());
+        assertEquals(user.getCreatedAt(), userDto.getCreatedAt());
+        assertEquals(user.getUpdatedAt(), userDto.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Map UserDto to User entity")
+    public void shouldMapUserDtoToUserEntity() {
+        UserDto userDto = userMocks.createUserDto(2L, "paul.test@mail.com", "Test", "Paul", "azerty123", false, false);
+
+        User user = userMapper.toEntity(userDto);
+
+        assertNotNull(user);
+        assertEquals(userDto.getId(), user.getId());
+        assertEquals(userDto.getEmail(), user.getEmail());
+        assertEquals(userDto.getLastName(), user.getLastName());
+        assertEquals(userDto.getFirstName(), user.getFirstName());
+        assertEquals(userDto.getPassword(), user.getPassword());
+        assertEquals(userDto.isAdmin(), user.isAdmin());
+        assertEquals(userDto.getCreatedAt(), user.getCreatedAt());
+        assertEquals(userDto.getUpdatedAt(), user.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("Map list of User entities to list of UserDtos")
+    public void shouldMapUserListToDtoList() {
+        List<User> users = Arrays.asList(
+            userMocks.createUser(3L, "alice@mail.com", "Test", "Alice", "alicePass", true, false),
+            userMocks.createUser(4L, "bob@mail.com", "Test", "Bob", "bobPass", false, false)
+        );
+
+        List<UserDto> userDtos = userMapper.toDto(users);
+        
+        assertNotNull(userDtos);
+        assertEquals(2, userDtos.size());
+        
+        assertEquals(3L, userDtos.get(0).getId());
+        assertEquals(users.get(0).getEmail(), userDtos.get(0).getEmail());
+        assertEquals(users.get(0).getLastName(), userDtos.get(0).getLastName());
+        assertEquals(users.get(0).getFirstName(), userDtos.get(0).getFirstName());
+        assertEquals(users.get(0).getPassword(), userDtos.get(0).getPassword());
+        assertTrue(userDtos.get(0).isAdmin());
+        
+        assertEquals(4L, userDtos.get(1).getId());
+        assertEquals(users.get(1).getEmail(), userDtos.get(1).getEmail());
+        assertEquals(users.get(1).getLastName(), userDtos.get(1).getLastName());
+        assertEquals(users.get(1).getFirstName(), userDtos.get(1).getFirstName());
+        assertEquals(users.get(1).getPassword(), userDtos.get(1).getPassword());
+        assertFalse(userDtos.get(1).isAdmin());
+    }
+
+    @Test
+    @DisplayName("Map list of UserDtos to list of User entities")
+    public void shouldMapDtoListToUserList() {
+        List<UserDto> userDtos = Arrays.asList(
+            userMocks.createUserDto(5L, "charlie@mail.com", "Test", "Charlie", "charliePass", true, false),
+            userMocks.createUserDto(6L, "diana@mail.com", "Test", "Diana", "dianaPass", false, false)
+        );
+
+        List<User> users = userMapper.toEntity(userDtos);
+
+        assertNotNull(users);
+        assertEquals(2, users.size());
+        
+        assertEquals(5L, users.get(0).getId());
+        assertEquals(userDtos.get(0).getEmail(), users.get(0).getEmail());
+        assertEquals(userDtos.get(0).getLastName(), users.get(0).getLastName());
+        assertEquals(userDtos.get(0).getFirstName(), users.get(0).getFirstName());
+        assertEquals(userDtos.get(0).getPassword(), users.get(0).getPassword());
+        assertTrue(users.get(0).isAdmin());
+        
+        assertEquals(6L, users.get(1).getId());
+        assertEquals(userDtos.get(1).getEmail(), users.get(1).getEmail());
+        assertEquals(userDtos.get(1).getLastName(), users.get(1).getLastName());
+        assertEquals(userDtos.get(1).getFirstName(), users.get(1).getFirstName());
+        assertEquals(userDtos.get(1).getPassword(), users.get(1).getPassword());
+        assertFalse(users.get(1).isAdmin());
+    }
+
+    @Test
+    @DisplayName("Handle long values in User to UserDto mapping")
+    public void shouldHandleLongValuesInUserToDto() {
+        User user = userMocks.createUser(7L, "verylong.email.address@verylongdomainmail.com", "A".repeat(30), "B".repeat(30), "C".repeat(150), true, true);
+        UserDto userDto = userMapper.toDto(user);
+
+        assertNotNull(userDto);
+        assertEquals(user.getId(), userDto.getId());
+        assertEquals(user.getEmail(), userDto.getEmail());
+        assertEquals(user.getLastName(), userDto.getLastName());
+        assertEquals(user.getFirstName(), userDto.getFirstName());
+        assertEquals(user.getPassword(), userDto.getPassword());
+        assertEquals(user.isAdmin(), userDto.isAdmin());
+    }
+
+    @Test
+    @DisplayName("Handle long values in UserDto to User mapping")
+    public void shouldHandleLongValuesInDtoToUser() {
+        UserDto userDto = userMocks.createUserDto(8L, "another.very.long.email@extremelylongdomain.com", 
+                                      "D".repeat(30), "E".repeat(30), "F".repeat(150), false, true);
+        User user = userMapper.toEntity(userDto);
+
+        assertNotNull(user);
+        assertEquals(userDto.getId(), user.getId());
+        assertEquals(userDto.getEmail(), user.getEmail());
+        assertEquals(userDto.getLastName(), user.getLastName());
+        assertEquals(userDto.getFirstName(), user.getFirstName());
+        assertEquals(userDto.getPassword(), user.getPassword());
+        assertEquals(userDto.isAdmin(), user.isAdmin());
+    }
+}


### PR DESCRIPTION
This pull request introduces unit tests for the `UserMapper`, `TeacherMapper`, and `SessionMapper` classes. It ensures proper mapping between entity and DTO objects for each class, covering both individual and list mappings, as well as handling edge cases such as null and long values.