### PR TITLE
test: Add unit tests for controllers

### DIFF
--- a/back/src/test/java/com/openclassrooms/starterjwt/controllers/AuthControllerTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/controllers/AuthControllerTest.java
@@ -1,0 +1,228 @@
+package com.openclassrooms.starterjwt.controllers;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openclassrooms.starterjwt.models.User;
+import com.openclassrooms.starterjwt.payload.request.LoginRequest;
+import com.openclassrooms.starterjwt.payload.request.SignupRequest;
+import com.openclassrooms.starterjwt.repository.UserRepository;
+import com.openclassrooms.starterjwt.security.jwt.JwtUtils;
+import com.openclassrooms.starterjwt.security.services.UserDetailsImpl;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthControllerTest {
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    public AuthControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+
+    private Authentication authentication;
+    private UserDetailsImpl userDetails;
+    private User user;
+    
+    @BeforeEach
+    public void setup() {
+        user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .firstName("Test")
+                .lastName("User")
+                .password("encodedPassword")
+                .admin(false)
+                .build();
+        
+        userDetails = UserDetailsImpl.builder()
+                .id(1L)
+                .username("test@example.com")
+                .firstName("Test")
+                .lastName("User")
+                .password("encodedPassword")
+                .admin(false)
+                .build();
+
+        authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+    }
+
+    @Test
+    @DisplayName("Login successful - Should return JWT token and user details")
+    public void testLoginSuccess() throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("test@example.com");
+        loginRequest.setPassword("password123");
+        
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(jwtUtils.generateJwtToken(authentication)).thenReturn("test-jwt-token");
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value("test-jwt-token"))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.username").value("test@example.com"))
+                .andExpect(jsonPath("$.firstName").value("Test"))
+                .andExpect(jsonPath("$.lastName").value("User"))
+                .andExpect(jsonPath("$.admin").value(false));
+    }
+    
+    @Test
+    @DisplayName("Login with admin role - Should return admin flag as true")
+    public void testLoginAsAdmin() throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("admin@example.com");
+        loginRequest.setPassword("adminPass");
+        
+        User adminUser = User.builder()
+                .id(2L)
+                .email("admin@example.com")
+                .firstName("Admin")
+                .lastName("User")
+                .password("encodedAdminPassword")
+                .admin(true)
+                .build();
+        
+        UserDetailsImpl adminDetails = UserDetailsImpl.builder()
+                .id(2L)
+                .username("admin@example.com")
+                .firstName("Admin")
+                .lastName("User")
+                .password("encodedAdminPassword")
+                .admin(true)
+                .build();
+        
+        Authentication adminAuth = mock(Authentication.class);
+        when(adminAuth.getPrincipal()).thenReturn(adminDetails);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(adminAuth);
+        when(jwtUtils.generateJwtToken(adminAuth)).thenReturn("admin-jwt-token");
+        when(userRepository.findByEmail("admin@example.com")).thenReturn(Optional.of(adminUser));
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value("admin-jwt-token"))
+                .andExpect(jsonPath("$.admin").value(true));
+    }
+    
+    @Test
+    @DisplayName("Login validation error - Should return 400 Bad Request")
+    public void testLoginValidationError() throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest());
+    }
+    
+    @Test
+    @DisplayName("Register successful - Should return success message")
+    public void testRegisterSuccess() throws Exception {
+        SignupRequest signupRequest = new SignupRequest();
+        signupRequest.setEmail("newuser@example.com");
+        signupRequest.setFirstName("New");
+        signupRequest.setLastName("User");
+        signupRequest.setPassword("password123");
+        
+        when(userRepository.existsByEmail("newuser@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("password123")).thenReturn("encodedPassword");
+
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signupRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("User registered successfully!"));
+    }
+    
+    @Test
+    @DisplayName("Register with existing email - Should return error message")
+    public void testRegisterWithExistingEmail() throws Exception {
+        SignupRequest signupRequest = new SignupRequest();
+        signupRequest.setEmail("existing@example.com");
+        signupRequest.setFirstName("Existing");
+        signupRequest.setLastName("User");
+        signupRequest.setPassword("password123");
+
+        when(userRepository.existsByEmail("existing@example.com")).thenReturn(true);
+
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signupRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Error: Email is already taken!"));
+    }
+    
+    @Test
+    @DisplayName("Register validation error - Should return 400 Bad Request")
+    public void testRegisterValidationError() throws Exception {
+        SignupRequest signupRequest = new SignupRequest();
+        signupRequest.setEmail("invalid@");
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signupRequest)))
+                .andExpect(status().isBadRequest());
+    }
+    
+    @Test
+    @DisplayName("Register should encode password")
+    public void testRegisterPasswordEncoding() throws Exception {
+        SignupRequest signupRequest = new SignupRequest();
+        signupRequest.setEmail("secure@example.com");
+        signupRequest.setFirstName("Secure");
+        signupRequest.setLastName("User");
+        signupRequest.setPassword("rawPassword");
+
+        when(userRepository.existsByEmail("secure@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("rawPassword")).thenReturn("encodedSecurePassword");
+
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signupRequest)))
+                .andExpect(status().isOk());
+        verify(passwordEncoder).encode("rawPassword");
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/controllers/SessionControllerTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/controllers/SessionControllerTest.java
@@ -1,0 +1,314 @@
+package com.openclassrooms.starterjwt.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openclassrooms.starterjwt.dto.SessionDto;
+import com.openclassrooms.starterjwt.mapper.SessionMapper;
+import com.openclassrooms.starterjwt.mocks.SessionMocks;
+import com.openclassrooms.starterjwt.mocks.TeacherMocks;
+import com.openclassrooms.starterjwt.mocks.UserMocks;
+import com.openclassrooms.starterjwt.models.Session;
+import com.openclassrooms.starterjwt.models.Teacher;
+import com.openclassrooms.starterjwt.models.User;
+import com.openclassrooms.starterjwt.services.SessionService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SessionControllerTest {
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+    private TeacherMocks teacherMocks = new TeacherMocks();
+    private UserMocks userMocks = new UserMocks();
+    private SessionMocks sessionMocks = new SessionMocks();
+
+    @Autowired
+    public SessionControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
+
+    @MockBean
+    private SessionService sessionService;
+
+    @MockBean
+    private SessionMapper sessionMapper;
+
+    private Session testSession;
+    private SessionDto testSessionDto;
+    private List<Session> testSessions;
+    private List<SessionDto> testSessionDtos;
+
+    @BeforeEach
+    public void setup() {
+        Teacher testTeacher = teacherMocks.createTeacher(1L, "Test", "André", false);
+        User testUser = userMocks.createUser(1L, "andre_test@mail.com", "Test", "Teacher", "private!123", false, false);
+
+        testSession = sessionMocks.createSession(1L, testTeacher, Arrays.asList(testUser), false, false);
+        testSessionDto = sessionMocks.createSessionDto(1L, null, testTeacher.getId(), Arrays.asList(testUser), false, false);
+        
+        Session testSession2 = sessionMocks.createSession(2L, testTeacher, Collections.emptyList(), false, false);
+        SessionDto testSessionDto2 = sessionMocks.createSessionDto(2L, null, testTeacher.getId(), Collections.emptyList(), false, false);
+        
+        testSessions = Arrays.asList(testSession, testSession2);
+        testSessionDtos = Arrays.asList(testSessionDto, testSessionDto2);
+
+        when(sessionMapper.toDto(testSession)).thenReturn(testSessionDto);
+        when(sessionMapper.toDto(any(Session.class))).thenReturn(testSessionDto);
+        when(sessionMapper.toDto(testSessions)).thenReturn(testSessionDtos);
+        when(sessionMapper.toEntity(any(SessionDto.class))).thenReturn(testSession);
+    }
+
+    @Test
+    @DisplayName("GET /api/session/{id} - Success")
+    public void testGetSessionById_Success() throws Exception {
+        when(sessionService.getById(1L)).thenReturn(testSession);
+
+        mockMvc.perform(get("/api/session/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Yoga session"))
+                .andExpect(jsonPath("$.description").value("A relaxing yoga session"))
+                .andExpect(jsonPath("$.teacher_id").value(1));
+
+        verify(sessionService).getById(1L);
+        verify(sessionMapper).toDto(testSession);
+    }
+
+    @Test
+    @DisplayName("GET /api/session/{id} - Not Found")
+    public void testGetSessionById_NotFound() throws Exception {
+        when(sessionService.getById(99L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/session/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isNotFound());
+
+        verify(sessionService).getById(99L);
+        verify(sessionMapper, never()).toDto(any(Session.class));
+    }
+
+    @Test
+    @DisplayName("GET /api/session/{id} - Invalid ID")
+    public void testGetSessionById_InvalidId() throws Exception {
+        mockMvc.perform(get("/api/session/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).getById(anyLong());
+    }
+
+    @Test
+    @DisplayName("GET /api/session - Success")
+    public void testGetAllSessions_Success() throws Exception {
+        when(sessionService.findAll()).thenReturn(testSessions);
+
+        mockMvc.perform(get("/api/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Yoga session"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].name").value("Yoga session"));
+
+        verify(sessionService).findAll();
+        verify(sessionMapper).toDto(testSessions);
+    }
+
+    @Test
+    @DisplayName("GET /api/session - Empty List")
+    public void testGetAllSessions_EmptyList() throws Exception {
+        when(sessionService.findAll()).thenReturn(Collections.emptyList());
+        when(sessionMapper.toDto(Collections.emptyList())).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+
+        verify(sessionService).findAll();
+        verify(sessionMapper).toDto(Collections.emptyList());
+    }
+
+    @Test
+    @DisplayName("POST /api/session - Success")
+    public void testCreateSession_Success() throws Exception {
+        when(sessionService.create(testSession)).thenReturn(testSession);
+
+        mockMvc.perform(post("/api/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com"))
+                .content(objectMapper.writeValueAsString(testSessionDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.name").value("Yoga session"));
+
+        verify(sessionMapper).toEntity(any(SessionDto.class));
+        verify(sessionService).create(any(Session.class));
+        verify(sessionMapper).toDto(any(Session.class));
+    }
+
+    @Test
+    @DisplayName("PUT /api/session/{id} - Success")
+    public void testUpdateSession_Success() throws Exception {
+        when(sessionService.update(eq(1L), any(Session.class))).thenReturn(testSession);
+
+        mockMvc.perform(put("/api/session/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com"))
+                .content(objectMapper.writeValueAsString(testSessionDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.name").value("Yoga session"));
+
+        verify(sessionMapper).toEntity(any(SessionDto.class));
+        verify(sessionService).update(eq(1L), any(Session.class));
+        verify(sessionMapper).toDto(any(Session.class));
+    }
+
+    @Test
+    @DisplayName("PUT /api/session/{id} - Invalid ID")
+    public void testUpdateSession_InvalidId() throws Exception {
+        mockMvc.perform(put("/api/session/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com"))
+                .content(objectMapper.writeValueAsString(testSessionDto)))
+                .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).update(anyLong(), any(Session.class));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session/{id} - Success")
+    public void testDeleteSession_Success() throws Exception {
+        when(sessionService.getById(1L)).thenReturn(testSession);
+
+        mockMvc.perform(delete("/api/session/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isOk());
+
+        verify(sessionService).getById(1L);
+        verify(sessionService).delete(1L);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session/{id} - Not Found")
+    public void testDeleteSession_NotFound() throws Exception {
+        when(sessionService.getById(99L)).thenReturn(null);
+
+        mockMvc.perform(delete("/api/session/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isNotFound());
+
+        verify(sessionService).getById(99L);
+        verify(sessionService, never()).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session/{id} - Invalid ID")
+    public void testDeleteSession_InvalidId() throws Exception {
+        mockMvc.perform(delete("/api/session/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("POST /api/session/{id}/participate/{userId} - Success")
+    public void testParticipate_Success() throws Exception {
+        doNothing().when(sessionService).participate(1L, 1L);
+
+        mockMvc.perform(post("/api/session/1/participate/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isOk());
+
+        verify(sessionService).participate(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("POST /api/session/{id}/participate/{userId} - Invalid IDs")
+    public void testParticipate_InvalidIds() throws Exception {
+        mockMvc.perform(post("/api/session/invalid/participate/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/session/1/participate/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).participate(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session/{id}/participate/{userId} - Success")
+    public void testNoLongerParticipate_Success() throws Exception {
+        doNothing().when(sessionService).noLongerParticipate(1L, 1L);
+
+        mockMvc.perform(delete("/api/session/1/participate/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isOk());
+
+        verify(sessionService).noLongerParticipate(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session/{id}/participate/{userId} - Invalid IDs")
+    public void testNoLongerParticipate_InvalidIds() throws Exception {
+        mockMvc.perform(delete("/api/session/invalid/participate/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(delete("/api/session/1/participate/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("andre@mail.com")))
+                .andExpect(status().isBadRequest());
+
+        verify(sessionService, never()).noLongerParticipate(anyLong(), anyLong());
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/controllers/TeacherControllerTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/controllers/TeacherControllerTest.java
@@ -1,0 +1,173 @@
+package com.openclassrooms.starterjwt.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.openclassrooms.starterjwt.dto.TeacherDto;
+import com.openclassrooms.starterjwt.mapper.TeacherMapper;
+import com.openclassrooms.starterjwt.models.Teacher;
+import com.openclassrooms.starterjwt.services.TeacherService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TeacherControllerTest {
+
+    private MockMvc mockMvc;
+    
+    @Autowired
+    public TeacherControllerTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @MockBean
+    private TeacherService teacherService;
+
+    @MockBean
+    private TeacherMapper teacherMapper;
+
+    private Teacher testTeacher;
+    private TeacherDto testTeacherDto;
+    private List<Teacher> testTeachers;
+    private List<TeacherDto> testTeacherDtos;
+
+    @BeforeEach
+    public void setup() {
+        testTeacher = Teacher.builder()
+                .id(1L)
+                .firstName("John")
+                .lastName("Doe")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        testTeacherDto = new TeacherDto();
+        testTeacherDto.setId(1L);
+        testTeacherDto.setFirstName("John");
+        testTeacherDto.setLastName("Doe");
+        testTeacherDto.setCreatedAt(testTeacher.getCreatedAt());
+        testTeacherDto.setUpdatedAt(testTeacher.getUpdatedAt());
+
+        Teacher testTeacher2 = Teacher.builder()
+                .id(2L)
+                .firstName("Jane")
+                .lastName("Smith")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        testTeachers = Arrays.asList(testTeacher, testTeacher2);
+
+        TeacherDto testTeacherDto2 = new TeacherDto();
+        testTeacherDto2.setId(2L);
+        testTeacherDto2.setFirstName("Jane");
+        testTeacherDto2.setLastName("Smith");
+        testTeacherDto2.setCreatedAt(testTeacher2.getCreatedAt());
+        testTeacherDto2.setUpdatedAt(testTeacher2.getUpdatedAt());
+
+        testTeacherDtos = Arrays.asList(testTeacherDto, testTeacherDto2);
+
+        when(teacherMapper.toDto(testTeacher)).thenReturn(testTeacherDto);
+        when(teacherMapper.toDto(testTeachers)).thenReturn(testTeacherDtos);
+    }
+
+    @Test
+    @DisplayName("GET /api/teacher/{id} - Success")
+    public void testGetTeacherById_Success() throws Exception {
+        when(teacherService.findById(1L)).thenReturn(testTeacher);
+
+        mockMvc.perform(get("/api/teacher/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.firstName").value("John"))
+                .andExpect(jsonPath("$.lastName").value("Doe"));
+
+        verify(teacherService).findById(1L);
+        verify(teacherMapper).toDto(testTeacher);
+    }
+
+    @Test
+    @DisplayName("GET /api/teacher/{id} - Not Found")
+    public void testGetTeacherById_NotFound() throws Exception {
+        when(teacherService.findById(99L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/teacher/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isNotFound());
+
+        verify(teacherService).findById(99L);
+        verify(teacherMapper, never()).toDto(any(Teacher.class));
+    }
+
+    @Test
+    @DisplayName("GET /api/teacher/{id} - Invalid ID")
+    public void testGetTeacherById_InvalidId() throws Exception {
+        mockMvc.perform(get("/api/teacher/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isBadRequest());
+
+        verify(teacherService, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("GET /api/teacher - Success")
+    public void testGetAllTeachers_Success() throws Exception {
+        when(teacherService.findAll()).thenReturn(testTeachers);
+
+        mockMvc.perform(get("/api/teacher")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].firstName").value("John"))
+                .andExpect(jsonPath("$[0].lastName").value("Doe"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].firstName").value("Jane"))
+                .andExpect(jsonPath("$[1].lastName").value("Smith"));
+
+        verify(teacherService).findAll();
+        verify(teacherMapper).toDto(testTeachers);
+    }
+
+    @Test
+    @DisplayName("GET /api/teacher - Empty List")
+    public void testGetAllTeachers_EmptyList() throws Exception {
+        when(teacherService.findAll()).thenReturn(Collections.emptyList());
+        when(teacherMapper.toDto(Collections.emptyList())).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/teacher")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+
+        verify(teacherService).findAll();
+        verify(teacherMapper).toDto(Collections.emptyList());
+    }
+}

--- a/back/src/test/java/com/openclassrooms/starterjwt/controllers/UserControllerTest.java
+++ b/back/src/test/java/com/openclassrooms/starterjwt/controllers/UserControllerTest.java
@@ -1,0 +1,212 @@
+package com.openclassrooms.starterjwt.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.openclassrooms.starterjwt.dto.UserDto;
+import com.openclassrooms.starterjwt.mapper.UserMapper;
+import com.openclassrooms.starterjwt.models.User;
+import com.openclassrooms.starterjwt.services.UserService;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    public UserControllerTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private UserMapper userMapper;
+
+    private User testUser;
+    private UserDto testUserDto;
+
+    @BeforeEach
+    public void setup() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .firstName("Test")
+                .lastName("User")
+                .password("encodedPassword")
+                .admin(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        testUserDto = new UserDto();
+        testUserDto.setId(1L);
+        testUserDto.setEmail("test@example.com");
+        testUserDto.setFirstName("Test");
+        testUserDto.setLastName("User");
+        testUserDto.setAdmin(false);
+        testUserDto.setCreatedAt(testUser.getCreatedAt());
+        testUserDto.setUpdatedAt(testUser.getUpdatedAt());
+
+        when(userMapper.toDto(testUser)).thenReturn(testUserDto);
+    }
+
+    @Test
+    @DisplayName("GET /api/user/{id} - Success")
+    public void testGetUserById_Success() throws Exception {
+        when(userService.findById(1L)).thenReturn(testUser);
+
+        mockMvc.perform(get("/api/user/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.firstName").value("Test"))
+                .andExpect(jsonPath("$.lastName").value("User"));
+
+        verify(userService).findById(1L);
+        verify(userMapper).toDto(testUser);
+    }
+
+    @Test
+    @DisplayName("GET /api/user/{id} -> User Not Found")
+    public void testGetUserById_NotFound() throws Exception {
+        when(userService.findById(99L)).thenReturn(null);
+        
+        mockMvc.perform(get("/api/user/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isNotFound());
+
+        verify(userService).findById(99L);
+        verify(userMapper, never()).toDto(any(User.class));
+    }
+
+    @Test
+    @DisplayName("GET /api/user/{id} -> Invalid ID")
+    public void testGetUserById_InvalidId() throws Exception {
+        mockMvc.perform(get("/api/user/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isBadRequest());
+                
+        verify(userService, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/user/{id} -> Success")
+    public void testDeleteUser_Success() throws Exception {
+        when(userService.findById(1L)).thenReturn(testUser);
+        
+        // Configuration explicite de l'utilisateur dans le SecurityContextHolder
+        org.springframework.security.core.userdetails.User userDetails = 
+            new org.springframework.security.core.userdetails.User(
+                testUser.getEmail(), "password", Collections.emptyList());
+        
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.getAuthorities());
+            
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(auth);
+        SecurityContextHolder.setContext(securityContext);
+
+        mockMvc.perform(delete("/api/user/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user(testUser.getEmail())))
+                .andExpect(status().isOk());
+                
+        verify(userService).findById(1L);
+        verify(userService).delete(1L);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/user/{id} -> Unauthorized")
+    public void testDeleteUser_Unauthorized() throws Exception {
+        User differentUser = User.builder()
+                .id(2L)
+                .email("other@example.com")
+                .firstName("Other")
+                .lastName("User")
+                .password("encodedPassword")
+                .admin(false)
+                .build();
+
+        when(userService.findById(2L)).thenReturn(differentUser);
+        
+        mockMvc.perform(delete("/api/user/2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isUnauthorized());
+                
+        verify(userService).findById(2L);
+        verify(userService, never()).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/user/{id} -> User Not Found")
+    public void testDeleteUser_NotFound() throws Exception {
+        when(userService.findById(99L)).thenReturn(null);
+        
+        mockMvc.perform(delete("/api/user/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isNotFound());
+                
+        verify(userService).findById(99L);
+        verify(userService, never()).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/user/{id} - Invalid ID")
+    public void testDeleteUser_InvalidId() throws Exception {
+        mockMvc.perform(delete("/api/user/invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.user("test@example.com")))
+                .andExpect(status().isBadRequest());
+                
+        verify(userService, never()).findById(any());
+        verify(userService, never()).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/user/{id} -> No Authentication")
+    public void testDeleteUser_NoAuthentication() throws Exception {
+        SecurityContextHolder.clearContext();
+        when(userService.findById(1L)).thenReturn(testUser);
+
+        mockMvc.perform(delete("/api/user/1")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+                
+        verify(userService, never()).delete(anyLong());
+    }
+}


### PR DESCRIPTION
 This pull request introduces unit tests for various controllers and authentication mechanisms, including:

- **UserController**: Tests for GET and DELETE requests with various scenarios (success, not found, unauthorized, invalid ID, no authentication).
- **TeacherController**: Tests for retrieving teacher information, handling valid and invalid IDs, and empty lists.
- **SessionController**: Comprehensive tests for CRUD operations and participation actions with different ID scenarios.
- **AuthController**: Tests for login and registration flows, covering validation, password encoding, and JWT generation.

Mocks and security configurations were used to ensure accurate test behavior across the different controllers.